### PR TITLE
To use the ESP8266 as a Wi-Fi station and access point simultaneously…

### DIFF
--- a/esp8266 Access point.bin
+++ b/esp8266 Access point.bin
@@ -1,0 +1,35 @@
+#include <ESP8266WiFi.h>
+
+const char* ssid = "YourWiFiSSID";          // Replace with your Wi-Fi network's SSID
+const char* password = "YourWiFiPassword";  // Replace with your Wi-Fi network's password
+
+const char* apSSID = "ESP8266AP";   // The SSID of the access point created by the ESP8266
+const char* apPassword = "12345678"; // Password for the access point
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.mode(WIFI_AP_STA); // Set Wi-Fi mode to station + access point
+
+  // Connect to the existing Wi-Fi network
+  Serial.print("Connecting to Wi-Fi...");
+  WiFi.begin(ssid, password);
+  
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("\nConnected to Wi-Fi!");
+  Serial.print("Station IP address: ");
+  Serial.println(WiFi.localIP());
+
+  // Create the access point
+  WiFi.softAP(apSSID, apPassword);
+
+  Serial.print("Access Point IP address: ");
+  Serial.println(WiFi.softAPIP());
+}
+
+void loop() {
+  // Your code goes here
+}


### PR DESCRIPTION
[…,](url) you can use the Arduino IDE and the ESP8266WiFi library. Below is an example of how you can set up the ESP8266 to act as both a Wi-Fi station (to connect to an existing Wi-Fi network) and an access point (to create its own Wi-Fi network)

This code will first connect the ESP8266 to the specified Wi-Fi network as a station using the provided SSID and password. Then, it will create an access point with the given SSID and password. The ESP8266 will act as a gateway between devices connected to its access point and the internet through the station connection.

Please make sure to replace "YourWiFiSSID" and "YourWiFiPassword" with your actual Wi-Fi network's SSID and password. Also, remember that when the ESP8266 is acting as an access point, it won't have access to the internet directly. If you want it to have internet access even in access point mode, you can set up additional configurations to allow the ESP8266 to forward traffic between its station and access point interfaces.